### PR TITLE
Fill in privacy considerations

### DIFF
--- a/draft-collink-6man-pio-pflag.xml
+++ b/draft-collink-6man-pio-pflag.xml
@@ -388,10 +388,18 @@ to be added
     </section>
 
     <section anchor="privacy">
-	    <name>Privacy Considerations</name>
-<t>
-To be added
-</t>
+      <name>Privacy Considerations</name>
+      <t>
+        Implementing the P flag on a host / receiving side enables other
+        systems on the network to trigger running DHCPv6 on that network.
+        Doing so may reveal some minor additional information about the host,
+        most prominently the hostname. This is the same consideration as for
+        the M flag.
+      </t>
+      <t>
+        No privacy considerations result from supporting the P flag on the
+        sender side.
+      </t>
     </section>
     
     <section anchor="IANA">


### PR DESCRIPTION
"P flag = start DHCPv6 = host tells the network a little bit about itself"

(Moved up security considerations to match the order of other drafts, there's no "common" order though)