### PR TITLE
Applicability

### DIFF
--- a/draft-ietf-6man-pio-pflag.xml
+++ b/draft-ietf-6man-pio-pflag.xml
@@ -106,7 +106,8 @@ IPv6-capable devices, especially mobile devices, usually have multiple global IP
 Extending the network to other devices or virtual systems requires that the device provide a way for those systems to obtain IP addresses. These addresses may be part of a prefix that is delegated to the device. Or they may be obtained by the device via other means such as by running SLAAC or DHCPv6 address assignment on the shared on-link prefix, and shared with other devices via ND proxying <xref target="RFC8981"/>.
 </t>
 <t>On large networks, the latter mode creates scalability issues, as the network infrastructure devices need to maintain state per address: IPv6 neighbor cache, SAVI mappings (<xref target="RFC7039"/>), VXLAN routes, etc.
-<xref target="I-D.ietf-v6ops-dhcp-pd-per-device"/> provides a a solution that uses DHCPv6 PD <xref target="RFC8415"/> to provide a client with a dedicated prefix, which can be used to form addresses. This solves the scaling issues because the amount of state that has to be maintained by the network does not depend on how many addresses are in use.
+<xref target="I-D.ietf-v6ops-dhcp-pd-per-device"/> provides a a solution that uses DHCPv6 PD <xref target="RFC8415"/> to provide a client with a dedicated prefix, which can be used to form addresses.
+This solves the scaling issues because the amount of state that has to be maintained by the network depends on the number of devices and does not depend anymore on how many addresses those devices are using.
 </t>
 
 <t>

--- a/draft-ietf-6man-pio-pflag.xml
+++ b/draft-ietf-6man-pio-pflag.xml
@@ -86,7 +86,7 @@
 
     <abstract>
  <t>
-This document defines a "P" flag in the Prefix Information Option of IPv6 Router Advertisements (RAs).
+This document defines a "P" flag in the Prefix Information Option (PIO) of IPv6 Router Advertisements (RAs).
 The flag is used to indicate that the network prefers that clients do not use the prefix provided in the PIO for SLAAC but request a prefix via DHCPv6 PD instead, and use that delegated prefix to form addresses.
 </t>
 
@@ -157,6 +157,49 @@ Also, in a multihoming situation, one upstream network might choose to assign pr
 <t>Note that the prefix(es) that the client obtains via DHCPv6 PD are not related in any way to the prefix(es) in the Router Advertisement which have the P bit set.</t>
 
     </section>
+
+<section anchor="flag-over">
+<name>P Flag Overview</name>
+<t>
+The P flag (also called DHCPv6-PD preferred flag) is a 1-bit PIO flag, located after the R flag (<xref target="RFC6275"/>).
+When set, indicates that this prefix SHOULD NOT be used for stateless address configuration.
+Instead the host SHOULD request a dedicated prefix via DHCPv6-PD and use that prefix for stateless address configuration.
+</t>
+
+<t>
+Adding the P flag reduces the PIO Reserved1 field (<xref target="RFC4861"/>, <xref target="RFC8425"/>) from 5 bits to 4 bits.
+The resulting format of the Prefix Information Option is as follows:
+</t>
+
+<figure align="center" anchor="fig_pio_new">
+<artwork align="center"><![CDATA[
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     Type      |    Length     | Prefix Length |L|A|R|P| Rsvd1 |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                         Valid Lifetime                        |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                       Preferred Lifetime                      |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           Reserved2                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                                                               +
+      |                                                               |
+      +                            Prefix                             +
+      |                                                               |
+      +                                                               +
+      |                                                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+]]></artwork>
+                      </figure>
+
+
+
+</section>
+
 <section anchor="Router">
 <name>Router Behaviour</name>
 <t>
@@ -301,95 +344,6 @@ DHCPv6 relays.
 Modifications to RFC-Mandated Behavior 
 </name>
 
-<section>
-<name>
-Changes to RFC4861
-</name>
-<t>
-This document makes the following changes to Section 4.6.2 of <xref target="RFC4861"/>,
-(last updated by <xref target="RFC6275"/>):
-</t>
-<t>
-OLD TEXT:
-</t>
-<t>
-==
-</t>
-<figure align="center" anchor="fig_Option">
-<artwork align="center"><![CDATA[
-       0                   1                   2                   3
-       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-      |     Type      |    Length     | Prefix Length |L|A|R|Reserved1|
-      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-]]></artwork>
-		      </figure>
-
-<t>
-===
-</t>
-<t>
-NEW TEXT
-</t>
-<t>
-===
-</t>
-<figure align="center" anchor="fig_Option_new">
-<artwork align="center"><![CDATA[
-       0                   1                   2                   3
-       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-      |     Type      |    Length     | Prefix Length |L|A|R|P| Rsvd1 |
-      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-]]></artwork>
-		      </figure>
-
-
-<t>
-OLD TEXT
-</t>
-<t>
-===
-</t>
-
-<t>
-
-A         1-bit autonomous address-configuration flag.  When set indicates that this prefix can be used for stateless address configuration as specified in [ADDRCONF].
-</t>
-
-<t>
-Reserved1     6-bit unused field.  It MUST be initialized to zero by the sender and MUST be ignored by the receiver.
-</t>
-
-
-<t>
-===
-</t>
-<t>
-NEW TEXT
-</t>
-<t>
-===
-</t>
-<t>
-
-A         1-bit autonomous address-configuration flag.  When set indicates that this prefix can be used for stateless address configuration as specified in [ADDRCONF].
-</t>
-<t>
-
-P             1-bit DHCPv6-PD flag. When set, indicates that this prefix SHOULD NOT be used for stateless address configuration. Instead the host SHOULD request a dedicated prefix via DHCPv6-PD and use that prefix for stateless address configuration.
-</t>
-
-<t>
-Rsvd1         4-bit unused field.  It MUST be initialized to zero by the sender and MUST be ignored by the receiver.
-</t>
-
-<t>
-===
-</t>
-
-
-</section>
 <section>
 <name>
 Changes to RFC4862

--- a/draft-ietf-6man-pio-pflag.xml
+++ b/draft-ietf-6man-pio-pflag.xml
@@ -164,6 +164,15 @@ Routers SHOULD set the P flag to zero by default, unless explicitly configured b
 </section>
 <section anchor="host">
 <name>Host Behaviour</name>
+
+<section>
+<name>Processing P Flag</name>
+<t>
+This specification only applies to hosts which support DHCPv6 prefix delegation.
+Hosts which do not support DHCPv6 prefix delegation MUST ignore the P flag.
+</t>
+</section>
+
    <section anchor="track">
    <name>Tracking and requesting prefixes</name>
 
@@ -518,7 +527,7 @@ a) If the P flag is set, start the DHCPv6 PD process and use the delegated prefi
     <section anchor="Acknowledgements" numbered="false">
       <name>Acknowledgements</name>
 <t>
-Thanks to Fernando Gont, Suresh Krishnan, Andrew McGregor, Tomek Mrugalski, Timothy Winters for the discussions, the input and all contribution.
+Thanks to Brian Carpenter, Fernando Gont, Suresh Krishnan, Andrew McGregor, Tomek Mrugalski, Timothy Winters for the discussions, the input and all contribution.
 </t>
     </section>
     

--- a/draft-ietf-6man-pio-pflag.xml
+++ b/draft-ietf-6man-pio-pflag.xml
@@ -16,7 +16,7 @@
 <rfc
   xmlns:xi="http://www.w3.org/2001/XInclude"
   category="std"
-  docName="draft-ietf-6man-pio-pflag-02"
+  docName="draft-ietf-6man-pio-pflag-03"
   ipr="trust200902"
   obsoletes=""
   updates="4861,4862"
@@ -25,7 +25,7 @@
   version="3">
   <front>
 <title abbrev="pio-p-flag">Signalling DHCPv6 Prefix Delegation Availability to Hosts</title>
-    <seriesInfo name="Internet-Draft" value="draft-collink-6man-pio-pflag-00"/>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-6man-pio-pflag-03"/>
 
  <author initials="L." surname="Colitti" fullname="Lorenzo Colitti">
       <organization>Google</organization>
@@ -143,7 +143,7 @@ The information is passed to the host via a P flag in the Prefix Information Opt
 <ul>
 <li>
 The information must be contained in the Router Advertisement because it must be available to the host before it decides to form IPv6 addresses from the PIO prefix using SLAAC. Otherwise, the host might use SLAAC to form IPv6 addresses from the PIO provided and start using them, even if a unique per-host prefix is available via DHCPv6 PD.
-This is suboptimal because if the host later acquires a prefix using DHCPv6 PD, it can either use both the prefix and SLAAC addresses, reducing the scalability benefits of using DHCPv6 PD, or can remove the SLAAC addresses, which would be disruptive for applications that are using them.
+Forming addresses via SLAAC is suboptimal because if the host later acquires a prefix using DHCPv6 PD, it can either use both the prefix and SLAAC addresses, reducing the scalability benefits of using DHCPv6 PD, or can remove the SLAAC addresses, which would be disruptive for applications that are using them.
 
 </li>
 <li>
@@ -159,7 +159,7 @@ Also, in a multihoming situation, one upstream network might choose to assign pr
 <section anchor="Router">
 <name>Router Behaviour</name>
 <t>
-Routers SHOULD set the P flag to zero by default, unless explicitly configured by the administrator, and SHOULD allow the opearator to set the P flag value for any given prefix.
+Routers SHOULD set the P flag to zero by default, unless explicitly configured by the administrator, and SHOULD allow the operator to set the P flag value for any given prefix.
 </t>
 </section>
 <section anchor="host">
@@ -211,7 +211,7 @@ In order to achieve the scalability benefits of using DHCPv6 PD, the host SHOULD
 </t>
 <ul>
 <li>It SHOULD NOT use SLAAC to obtain IPv6 addresses from prefix(es) with the P bit set.</li>
-<li>It SHOULD NOT request individual IPv6 addresses from DHPCv6, i.e., it SHOULD NOT include any IA_NA or IA_TA options in Solicit, Renew or Rebind messages.</li>
+<li>It SHOULD NOT request individual IPv6 addresses from DHCPv6, i.e., it SHOULD NOT include any IA_NA or IA_TA options in Solicit, Renew or Rebind messages.</li>
 </ul>
 	   
 <t>If the host does not obtain any suitable prefixes via DHCPv6 PD, it MAY choose to fall back to other address assignment mechanisms, such as forming addresses via SLAAC (if the PIO has the A flag set to 1) and/or requesting addresses via DHCPv6.</t>
@@ -427,7 +427,7 @@ NEW TEXT:
 ===
 </t>
 <t>
-a) If the P flag is set, start the DHCPv6 PD process and use the delegated prefix to assign addresses to the interfaces as described in draft-collink-6man-pio-pflag. The Prefix Information option SHOULD be processed as if A flag is set to zero.
+a) If the P flag is set, start the DHCPv6 PD process and use the delegated prefix to assign addresses to the interfaces as described in draft-ietf-6man-pio-pflag. The Prefix Information option SHOULD be processed as if the A flag is set to zero.
 </t>
 <t>
 ===
@@ -443,7 +443,7 @@ a) If the P flag is set, start the DHCPv6 PD process and use the delegated prefi
       <name>Security Considerations</name>
 <t>
 	The mechanism described in this document relies on the information provided in the Router Advertisement and therefore shares the same security model as SLAAC.
-	If the network doesn't implement RA Guard <xref target="RFC6105"/>, an attacker might sent RAs containing the PIO used by the network, set P flag to 1 and force hosts to ignore A flag. 
+	If the network doesn't implement RA Guard <xref target="RFC6105"/>, an attacker might send RAs containing the PIO used by the network, set the P flag to 1 and force hosts to ignore the A flag. 
 	In the absense of DHCPv6 PD infrastructure, hosts would experience delays in obtaining IPv6 addresses (as no delegated prefixes are available, hosts MAY choose to fallback to SLAAC).
 </t>
 	    <t>
@@ -527,7 +527,7 @@ a) If the P flag is set, start the DHCPv6 PD process and use the delegated prefi
     <section anchor="Acknowledgements" numbered="false">
       <name>Acknowledgements</name>
 <t>
-Thanks to Brian Carpenter, Fernando Gont, Suresh Krishnan, Andrew McGregor, Tomek Mrugalski, Timothy Winters for the discussions, the input and all contribution.
+Thanks to Brian Carpenter, Tim Chown, Fernando Gont, Suresh Krishnan, Andrew McGregor, Tomek Mrugalski, Timothy Winters for the discussions, the input and all contribution.
 </t>
     </section>
     

--- a/draft-ietf-6man-pio-pflag.xml
+++ b/draft-ietf-6man-pio-pflag.xml
@@ -399,7 +399,7 @@ a) If the P flag is set, start the DHCPv6 PD process and use the delegated prefi
 <t>
 	The mechanism described in this document relies on the information provided in the Router Advertisement and therefore shares the same security model as SLAAC.
 	If the network doesn't implement RA Guard <xref target="RFC6105"/>, an attacker might send RAs containing the PIO used by the network, set the P flag to 1 and force hosts to ignore the A flag. 
-	In the absense of DHCPv6 PD infrastructure, hosts would experience delays in obtaining IPv6 addresses (as no delegated prefixes are available, hosts MAY choose to fallback to SLAAC).
+	In the absence of DHCPv6 PD infrastructure, hosts would experience delays in obtaining IPv6 addresses (as no delegated prefixes are available, hosts MAY choose to fallback to SLAAC).
 </t>
 	    <t>
 		    The attacker might force hosts to oscillate between DHCPv6 PD and PIO-based SLAAC by sending the same set of PIOs with and then w/o P flag set.

--- a/draft-ietf-6man-pio-pflag.xml
+++ b/draft-ietf-6man-pio-pflag.xml
@@ -19,7 +19,7 @@
   docName="draft-ietf-6man-pio-pflag-03"
   ipr="trust200902"
   obsoletes=""
-  updates="4861,4862"
+  updates="4862"
   submissionType="IETF"
   xml:lang="en"
   version="3">


### PR DESCRIPTION
Brian's comments:
1. Make it explicit that hosts w/o DHCPv6-PD support MUST ignore the flag.

Tim's comments.
- Rephrasing the scalability benefit
-  Fixing typos